### PR TITLE
Fixed MIDI_V0 MThd validation

### DIFF
--- a/src/MthdHeader.cpp
+++ b/src/MthdHeader.cpp
@@ -28,8 +28,9 @@ bool MthdHeader::isOk()
 	switch (m_formatType)
 	{
 	case MIDI_V0:
-		if(m_mtrkChunksCount != 0)
-			return false;
+		if(m_mtrkChunksCount == 1 || m_mtrkChunksCount == 0)
+			return true;
+		return false;
 	// For V1 and V2 number of tracks need to be more than zero
 	case MIDI_V1:
 	case MIDI_V2:


### PR DESCRIPTION
The MIDI_V0 validation was false so that it would always return false when the chunkscount was set to anything as when the chunkscount would be 0 which should return true it wouldnt return true but go down to check MIDI_V1 and V2 where it would check if it would be 0 and then return false. 